### PR TITLE
Add an SDL2 example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,7 +2021,9 @@ dependencies = [
  "cfg_aliases 0.2.0",
  "eframe",
  "enum_dispatch",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
+ "sdl2",
  "smallvec",
  "softbuffer",
  "strum",
@@ -2444,6 +2452,30 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "sdl2"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8356b2697d1ead5a34f40bcc3c5d3620205fe0c7be0a14656223bfeec0258891"
+dependencies = [
+ "bitflags 1.3.2",
+ "lazy_static",
+ "libc",
+ "raw-window-handle 0.5.2",
+ "sdl2-sys",
+]
+
+[[package]]
+name = "sdl2-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bcacfdd45d539fb5785049feb0038a63931aa896c7763a2a12e125ec58bd29"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "version-compare",
 ]
 
 [[package]]
@@ -2930,6 +2962,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,11 @@ windows-ink = ["dep:windows"]
 [dev-dependencies]
 eframe = "0.26.2" 
 winit = "0.29.15"
-tiny-skia = {version = "0.11.4", default-features = false, features = ["std", "simd"]}
+tiny-skia = { version = "0.11.4", default-features = false, features = ["std", "simd"] }
 usb-ids = "1.2024.2"
 softbuffer = "0.4.1"
+sdl2 = { version = "0.36.0", features = ["raw-window-handle"] }
+rwh_05 = { package = "raw-window-handle", version = "0.5.0" }
 
 [build-dependencies]
 cfg_aliases = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Cross-platform high-level tablet/pad/stylus library, reporting connected hardware features and providing easy-to-use
 event-based access to user input.
 
+## [Examples](examples/README.md)
+See [the examples](examples/README.md) for features and usage with several windowing abstractions.
+In particular, `eframe-viewer` provides a nice interface to debug your devices and view many of the capabilities of this crate.
+
 ## Platform Support
 | Platform                             |      Support |
 |--------------------------------------|-------------:|

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,3 +16,12 @@ frame lag - the events api will never coalesce events, leaving them as detailed 
 Demos integration with `eframe` for exploring the data this crate provides, including listing connected tablet/pad/stylus
 hardware with their capabilities. Also includes a test area where you can play with and visualize the distance/tilt/pressure
 capabilities of your tablet and observe the raw event stream.
+
+## `sdl2`
+Demos integration with the `sdl2` crate, and does little more than that. Currently, `sdl2` requires the use of `raw-window-handle = 0.5.0`
+whereas `octotablet` requires the use of `raw-window-handle = 0.6.0`, this demo shows how to bridge between the two. In the future,
+this should be fixed.
+Octotablet currently requires wayland, which can be accessed via the environment variable `SDL_VIDEODRIVER`.
+```bash
+SDL_VIDEODRIVER=wayland cargo run --example sdl2
+```

--- a/examples/sdl2.rs
+++ b/examples/sdl2.rs
@@ -1,0 +1,164 @@
+//! Adapted from the `sdl2` `demo.rs` example.
+//!
+//! Provides simple access to a manager, and does little more.
+
+use std::error::Error;
+
+// SDL2 supports raw-window-handle 0.5.0, but octotablet requires 0.6.0 due to stronger
+// lifetime and safety guarantees. Here, we build an unsafe bridge betweem the two, pinky promising that
+// we're upholding those missing safety contracts ourselves!
+
+// In the future, this should be cleaned up...
+mod rwh_bridge {
+    struct RwhBridge<W>(W);
+    impl<W: rwh_05::HasRawDisplayHandle> raw_window_handle::HasDisplayHandle for RwhBridge<W> {
+        fn display_handle(
+            &self,
+        ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+            // Convert rwh_05 -> rwh_06
+            let raw = match self.0.raw_display_handle() {
+                // Wayland...
+                rwh_05::RawDisplayHandle::Wayland(rwh_05::WaylandDisplayHandle {
+                    display, ..
+                }) => raw_window_handle::WaylandDisplayHandle::new(
+                    std::ptr::NonNull::new(display).expect("null wayland handle"),
+                )
+                .into(),
+                // Windows 32... Has no display handle!
+                rwh_05::RawDisplayHandle::Windows(_) => {
+                    raw_window_handle::WindowsDisplayHandle::new().into()
+                }
+                // Octotablet has limited platform support, we don't need to worry about these as they'd fail anyway.
+                _ => unimplemented!("unsupported display system"),
+            };
+
+            // Safety: guaranteed by precondition, see [rwh_bridge::bridge]
+            Ok(unsafe { raw_window_handle::DisplayHandle::borrow_raw(raw) })
+        }
+    }
+    impl<W: rwh_05::HasRawWindowHandle> raw_window_handle::HasWindowHandle for RwhBridge<W> {
+        fn window_handle(
+            &self,
+        ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+            // Convert rwh_05 -> rwh_06
+            let raw = match self.0.raw_window_handle() {
+                // Wayland...
+                rwh_05::RawWindowHandle::Wayland(rwh_05::WaylandWindowHandle {
+                    surface, ..
+                }) => raw_window_handle::WaylandWindowHandle::new(
+                    std::ptr::NonNull::new(surface).expect("null wayland handle"),
+                )
+                .into(),
+                // Windows 32...
+                rwh_05::RawWindowHandle::Win32(rwh_05::Win32WindowHandle {
+                    hinstance,
+                    hwnd,
+                    ..
+                }) => {
+                    let mut new = raw_window_handle::Win32WindowHandle::new(
+                        (hwnd as isize).try_into().expect("null hwnd"),
+                    );
+                    new.hinstance = (hinstance as isize).try_into().ok();
+                    new.into()
+                }
+                // Octotablet has limited platform support, we don't need to worry about these as they'd fail anyway.
+                _ => unimplemented!("unsupported display system"),
+            };
+
+            // Safety: guaranteed by precondition, see [rwh_bridge::bridge]
+            Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(raw) })
+        }
+    }
+
+    /// Bridge between rwh_05 and rwh_06.
+    /// # Safety:
+    /// The window and display handles must remain valid for the entire lifetime of the returned opaque object.
+    pub unsafe fn bridge<W>(
+        window: W,
+    ) -> impl raw_window_handle::HasDisplayHandle + raw_window_handle::HasWindowHandle
+    where
+        W: rwh_05::HasRawDisplayHandle + rwh_05::HasRawWindowHandle,
+    {
+        RwhBridge(window)
+    }
+}
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    let sdl_context = sdl2::init()?;
+    let video = sdl_context.video()?;
+    // For this simple example, our drawing code is bad, don't double buffer or it'll flicker.
+    video.gl_attr().set_double_buffer(false);
+
+    let window = video
+        .window("Octotablet", 800, 600)
+        .position_centered()
+        .opengl()
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut canvas = window.into_canvas().build()?;
+
+    // Safety: `manager` must not outlive our window.
+    // Drop order provides this guarantee! However, this isn't quite strong enough, as SDL could internally thrash it's
+    // window handles if it so desires. Hence the unsafe. We trust this isn't the case :P
+    let mut manager =
+        unsafe { octotablet::Builder::new().build_raw(rwh_bridge::bridge(canvas.window()))? };
+
+    canvas.set_draw_color(sdl2::pixels::Color::BLACK);
+    canvas.clear();
+    canvas.set_draw_color(sdl2::pixels::Color::WHITE);
+    canvas.present();
+
+    let mut event_pump = sdl_context.event_pump()?;
+    let mut stylus_down = false;
+
+    'running: loop {
+        use sdl2::{event::Event, keyboard::Keycode};
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit { .. }
+                | Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => break 'running,
+                _ => {}
+            }
+        }
+        for event in manager.pump()? {
+            use octotablet::events::{Event, ToolEvent};
+            // For this simple example, ignore everything else
+            let Event::Tool { event, .. } = event else {
+                continue;
+            };
+            match event {
+                ToolEvent::Down => stylus_down = true,
+                ToolEvent::Up | ToolEvent::Out => stylus_down = false,
+
+                ToolEvent::Pose(p) => {
+                    if stylus_down {
+                        let size = p.pressure.get().unwrap_or(1.0) * 10.0;
+                        let size = size as u32;
+                        let rect = sdl2::rect::Rect::from_center(
+                            (p.position[0] as i32, p.position[1] as i32),
+                            size,
+                            size,
+                        );
+                        canvas.draw_rect(rect)?;
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        canvas.present();
+
+        ::std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+
+    // Be very particular of our drop order.
+    // This ensures the user cannot accidentally move out of canvas without also destroying manager.
+    drop(manager);
+    drop(canvas);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #8

Demonstrates how to use this crate with the [`sdl2`](https://github.com/Rust-SDL2/rust-sdl2/) crate. This is, unfortunately, no straightforward task and requires the use of a wrapper type to implement the correct traits.

In the future, it would be best if `octotablet` had support for more versions of `raw-window-handle` directly, but the safety guarantees of previous versions are very weak and doing so soundly is a big ask!