### PR TITLE
Xinput2 Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# (Unreleased)
+* New variant `Backend::XorgXinput2`
+* New default feature `xorg-xinput2`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,7 @@ dependencies = [
  "wayland-protocols",
  "windows 0.54.0",
  "winit",
+ "x11-dl",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,7 @@ dependencies = [
  "wayland-protocols",
  "windows 0.54.0",
  "winit",
- "x11-dl",
+ "x11rb",
 ]
 
 [[package]]
@@ -3723,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
@@ -3738,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,14 @@ strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 smallvec = "1.13.1"
 
-# Wayland `tablet_unstable_v2` deps.
 # Crazy `cfg` stolen verbatim from winit's Cargo.toml as I assume they have more wisdom than I
 [target.'cfg(any(docsrs, all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos")))))'.dependencies]
+# Wayland `tablet_unstable_v2` deps.
 wayland-backend = { version = "0.3.3", features = ["client_system"], optional = true }
 wayland-client = { version = "0.31.2", optional = true }
 wayland-protocols = { version = "0.31.2", features = ["client", "unstable"], optional = true }
+# Xorg deps.
+x11-dl = { version = "2.21.0", optional = true }
 
 # Windows Ink `RealTimeStylus`
 [target.'cfg(any(docsrs, target_os = "windows"))'.dependencies.windows]
@@ -62,11 +64,13 @@ features = [
 ]
 
 [features]
-default = ["wayland-tablet-unstable-v2", "windows-ink"]
+default = ["wayland-tablet-unstable-v2", "xorg-xinput2", "windows-ink"]
 
 # Wayland `tablet_unstable_v2` support
 # Note: "unstable" here refers to the protocol itself, not to the stability of it's integration into this crate!
 wayland-tablet-unstable-v2 = ["dep:wayland-backend", "dep:wayland-client", "dep:wayland-protocols"]
+
+xorg-xinput2 = ["dep:x11-dl"]
 
 # Windows Ink `RealTimeStylus` support
 windows-ink = ["dep:windows"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,10 @@ smallvec = "1.13.1"
 wayland-backend = { version = "0.3.3", features = ["client_system"], optional = true }
 wayland-client = { version = "0.31.2", optional = true }
 wayland-protocols = { version = "0.31.2", features = ["client", "unstable"], optional = true }
-# Xorg deps.
-x11-dl = { version = "2.21.0", optional = true }
+
+# Xorg `xinput2` deps. We use x11rb RustConnection as xcb doesn't support xinput2 out-of-box
+# and xlib cannot be soundly used due to its use of global variables.
+x11rb = { version = "0.13.1", features = ["xinput", "extra-traits"], optional = true }
 
 # Windows Ink `RealTimeStylus`
 [target.'cfg(any(docsrs, target_os = "windows"))'.dependencies.windows]
@@ -70,7 +72,7 @@ default = ["wayland-tablet-unstable-v2", "xorg-xinput2", "windows-ink"]
 # Note: "unstable" here refers to the protocol itself, not to the stability of it's integration into this crate!
 wayland-tablet-unstable-v2 = ["dep:wayland-backend", "dep:wayland-client", "dep:wayland-protocols"]
 
-xorg-xinput2 = ["dep:x11-dl"]
+xorg-xinput2 = ["dep:x11rb"]
 
 # Windows Ink `RealTimeStylus` support
 windows-ink = ["dep:windows"]

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ fn main() {
         // Wayland tablet is requested and available. Adapted from winit.
         // lonngg cfg = The feature is on, and (docs or (supported platform and not unsupported platform))
         wl_tablet: { all(feature = "wayland-tablet-unstable-v2", any(docsrs, all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos"))))) },
+        // Same as above but for xlib `xinput2` support.
+        xinput2: { all(feature = "xorg-xinput2", any(docsrs, all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos"))))) },
         // Ink RealTimeStylus is requested and available
         ink_rts: { all(feature = "windows-ink", any(docsrs, target_os = "windows")) },
     }

--- a/examples/eframe-viewer/main.rs
+++ b/examples/eframe-viewer/main.rs
@@ -53,14 +53,12 @@ impl EventFilter {
             },
             Event::Tablet { .. } => true,
             Event::Pad { event, .. } => match event {
-                PadEvent::Group { event, .. } => match event {
-                    PadGroupEvent::Ring { event, .. } | PadGroupEvent::Strip { event, .. } => {
-                        match event {
-                            TouchStripEvent::Frame(..) => self.frames,
-                            TouchStripEvent::Pose(..) => self.poses,
-                            _ => true,
-                        }
-                    }
+                PadEvent::Group {
+                    event: PadGroupEvent::Ring { event, .. } | PadGroupEvent::Strip { event, .. },
+                    ..
+                } => match event {
+                    TouchStripEvent::Frame(..) => self.frames,
+                    TouchStripEvent::Pose(..) => self.poses,
                     _ => true,
                 },
                 _ => true,
@@ -215,6 +213,8 @@ impl eframe::App for Viewer {
                 });
         });
 
+        // Set the scale factor. Notably, this does *not* include the window's scale factor!
+        self.state.egui_scale_factor = ctx.zoom_factor();
         // update the state with the new events!
         self.state.extend(events);
 

--- a/examples/sdl2.rs
+++ b/examples/sdl2.rs
@@ -24,6 +24,16 @@ mod rwh_bridge {
                     std::ptr::NonNull::new(display).expect("null wayland handle"),
                 )
                 .into(),
+                // Xlib...
+                rwh_05::RawDisplayHandle::Xlib(rwh_05::XlibDisplayHandle {
+                    display,
+                    screen,
+                    ..
+                }) => raw_window_handle::XlibDisplayHandle::new(
+                    std::ptr::NonNull::new(display),
+                    screen,
+                )
+                .into(),
                 // Windows 32... Has no display handle!
                 rwh_05::RawDisplayHandle::Windows(_) => {
                     raw_window_handle::WindowsDisplayHandle::new().into()
@@ -48,6 +58,17 @@ mod rwh_bridge {
                 }) => raw_window_handle::WaylandWindowHandle::new(
                     std::ptr::NonNull::new(surface).expect("null wayland handle"),
                 )
+                .into(),
+                // Xlib...
+                rwh_05::RawWindowHandle::Xlib(rwh_05::XlibWindowHandle {
+                    window,
+                    visual_id,
+                    ..
+                }) => {
+                    let mut rwh = raw_window_handle::XlibWindowHandle::new(window);
+                    rwh.visual_id = visual_id;
+                    rwh
+                }
                 .into(),
                 // Windows 32...
                 rwh_05::RawWindowHandle::Win32(rwh_05::Win32WindowHandle {

--- a/examples/sdl2.rs
+++ b/examples/sdl2.rs
@@ -34,6 +34,16 @@ mod rwh_bridge {
                     screen,
                 )
                 .into(),
+                // Xcb...
+                rwh_05::RawDisplayHandle::Xcb(rwh_05::XcbDisplayHandle {
+                    connection,
+                    screen,
+                    ..
+                }) => raw_window_handle::XcbDisplayHandle::new(
+                    std::ptr::NonNull::new(connection),
+                    screen,
+                )
+                .into(),
                 // Windows 32... Has no display handle!
                 rwh_05::RawDisplayHandle::Windows(_) => {
                     raw_window_handle::WindowsDisplayHandle::new().into()
@@ -67,6 +77,17 @@ mod rwh_bridge {
                 }) => {
                     let mut rwh = raw_window_handle::XlibWindowHandle::new(window);
                     rwh.visual_id = visual_id;
+                    rwh
+                }
+                .into(),
+                // Xcb...
+                rwh_05::RawWindowHandle::Xcb(rwh_05::XcbWindowHandle {
+                    window, visual_id, ..
+                }) => {
+                    let mut rwh = raw_window_handle::XcbWindowHandle::new(
+                        std::num::NonZeroU32::new(window).expect("null xcb window"),
+                    );
+                    rwh.visual_id = std::num::NonZeroU32::new(visual_id);
                     rwh
                 }
                 .into(),

--- a/examples/winit-paint.rs
+++ b/examples/winit-paint.rs
@@ -199,6 +199,7 @@ fn main() {
     let event_loop = winit::event_loop::EventLoopBuilder::<()>::default()
         .build()
         .expect("start event loop");
+    event_loop.listen_device_events(winit::event_loop::DeviceEvents::Always);
     let window = std::sync::Arc::new(
         winit::window::WindowBuilder::default()
             .with_inner_size(PhysicalSize::new(512u32, 512u32))
@@ -209,10 +210,15 @@ fn main() {
 
     // To allow us to draw on the screen without pulling in a whole GPU package,
     // we use `softbuffer` for presentation and `tiny-skia` for drawing
-    let mut pixmap = tiny_skia::Pixmap::new(512, 512).unwrap();
+    let mut pixmap =
+        tiny_skia::Pixmap::new(window.inner_size().width, window.inner_size().height).unwrap();
     let softbuffer = softbuffer::Context::new(window.as_ref()).expect("init softbuffer");
     let mut surface =
         softbuffer::Surface::new(&softbuffer, &window).expect("make presentation surface");
+    surface.resize(
+        window.inner_size().width.try_into().unwrap(),
+        window.inner_size().height.try_into().unwrap(),
+    );
 
     // Fetch the tablets, using our window's handle for access.
     // Since we `Arc'd` our window, we get the safety of `build_shared`. Where this is not possible,

--- a/examples/winit-paint.rs
+++ b/examples/winit-paint.rs
@@ -159,6 +159,7 @@ impl Painter {
                     }
                     // Positioning data, continue drawing!
                     ToolEvent::Pose(mut pose) => {
+                        println!("{:?} - x {}", tool.name, pose.position[0]);
                         // If there's a painter, paint on it!
                         // If not, we haven't hit the `Down` event yet.
                         if let Some(painter) = self.tools.get_mut(&tool.id()) {
@@ -215,10 +216,12 @@ fn main() {
     let softbuffer = softbuffer::Context::new(window.as_ref()).expect("init softbuffer");
     let mut surface =
         softbuffer::Surface::new(&softbuffer, &window).expect("make presentation surface");
-    surface.resize(
-        window.inner_size().width.try_into().unwrap(),
-        window.inner_size().height.try_into().unwrap(),
-    );
+    surface
+        .resize(
+            window.inner_size().width.try_into().unwrap(),
+            window.inner_size().height.try_into().unwrap(),
+        )
+        .unwrap();
 
     // Fetch the tablets, using our window's handle for access.
     // Since we `Arc'd` our window, we get the safety of `build_shared`. Where this is not possible,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -118,6 +118,30 @@ impl Builder {
                     },
                 ))
             }
+            #[cfg(xinput2)]
+            raw_window_handle::RawDisplayHandle::Xlib(_)
+            | raw_window_handle::RawDisplayHandle::Xcb(_) => {
+                // We don't actually care about the dispaly handle for xlib! We need the *window* id instead.
+                // (We manage our own connection and snoop the window events from there.)
+                // As such, we accept both Xlib and Xcb, since we only care about the numeric window ID which is *server* defined,
+                // not client library defined.
+                let window = match rwh.window_handle()?.as_raw() {
+                    raw_window_handle::RawWindowHandle::Xlib(
+                        raw_window_handle::XlibWindowHandle { window, .. },
+                    ) => window,
+                    raw_window_handle::RawWindowHandle::Xcb(
+                        raw_window_handle::XcbWindowHandle { window, .. },
+                    ) => u64::from(window.get()),
+                    // The display handle said it was one of these!!
+                    _ => unreachable!(),
+                };
+
+                Ok(crate::platform::PlatformManager::XInput2(
+                    // Safety: forwarded to this fn's contract.
+                    // Fixme: unwrap.
+                    unsafe { crate::platform::xinput2::Manager::build_window(self, window) },
+                ))
+            }
             #[cfg(ink_rts)]
             raw_window_handle::RawDisplayHandle::Windows(_) => {
                 // We need the window handle for this :V

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -252,7 +252,7 @@ impl<'manager> EventIterator<'manager> {
                                 .tablets()
                                 .iter()
                                 .find(|t| t.internal_id == tablet)
-                                .unwrap(),
+                                .ok_or(())?,
                         },
                         RawTool::Down => ToolEvent::Down,
                         RawTool::Button { button_id, pressed } => ToolEvent::Button {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub enum Backend {
     ///
     /// **Note**: "unstable" here refers to the protocol itself, not to the stability of its integration into this crate!
     WaylandTabletUnstableV2,
+    /// [`XInput2`](https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt)
+    XorgXInput2,
     /// [`RealTimeStylus`](https://learn.microsoft.com/en-us/windows/win32/tablet/realtimestylus-reference)
     ///
     /// The use of this interface avoids some common problems with the use of Windows Ink in drawing applications,
@@ -124,6 +126,8 @@ impl Manager {
         match self.internal {
             #[cfg(wl_tablet)]
             platform::PlatformManager::Wayland(_) => Backend::WaylandTabletUnstableV2,
+            #[cfg(xinput2)]
+            platform::PlatformManager::XInput2(_) => Backend::XorgXInput2,
             #[cfg(ink_rts)]
             platform::PlatformManager::Ink(_) => Backend::WindowsInkRealTimeStylus,
         }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -3,6 +3,8 @@
 pub(crate) mod ink;
 #[cfg(wl_tablet)]
 pub(crate) mod wl;
+#[cfg(xinput2)]
+pub(crate) mod xinput2;
 
 /// Holds any one of the internal platform IDs.
 /// Since these are always sealed away as an implementation detail, we can always
@@ -12,6 +14,8 @@ pub(crate) mod wl;
 pub(crate) enum InternalID {
     #[cfg(wl_tablet)]
     Wayland(wl::ID),
+    #[cfg(xinput2)]
+    XInput2(xinput2::ID),
     #[cfg(ink_rts)]
     Ink(ink::ID),
 }
@@ -54,6 +58,17 @@ impl InternalID {
             _ => Self::unwrap_failure(),
         }
     }
+    #[cfg(xinput2)]
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn unwrap_xinput2(&self) -> &xinput2::ID {
+        #[allow(unreachable_patterns)]
+        #[allow(clippy::match_wildcard_for_single_variants)]
+        match self {
+            Self::XInput2(id) => id,
+            _ => Self::unwrap_failure(),
+        }
+    }
     #[cfg(ink_rts)]
     #[inline]
     #[allow(dead_code)]
@@ -72,6 +87,12 @@ impl From<wl::ID> for InternalID {
         Self::Wayland(value)
     }
 }
+#[cfg(xinput2)]
+impl From<xinput2::ID> for InternalID {
+    fn from(value: xinput2::ID) -> Self {
+        Self::XInput2(value)
+    }
+}
 #[cfg(ink_rts)]
 impl From<ink::ID> for InternalID {
     fn from(value: ink::ID) -> Self {
@@ -86,6 +107,8 @@ impl From<ink::ID> for InternalID {
 pub(crate) enum ButtonID {
     #[cfg(wl_tablet)]
     Wayland(wl::ButtonID),
+    #[cfg(xinput2)]
+    XInput2(xinput2::ButtonID),
     #[cfg(ink_rts)]
     Ink(ink::ButtonID),
 }
@@ -128,6 +151,17 @@ impl ButtonID {
             _ => Self::unwrap_failure(),
         }
     }
+    #[cfg(xinput2)]
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn unwrap_xinput2(&self) -> &xinput2::ButtonID {
+        #[allow(unreachable_patterns)]
+        #[allow(clippy::match_wildcard_for_single_variants)]
+        match self {
+            Self::XInput2(id) => id,
+            _ => Self::unwrap_failure(),
+        }
+    }
     #[cfg(ink_rts)]
     #[inline]
     #[allow(dead_code)]
@@ -146,6 +180,12 @@ impl From<wl::ButtonID> for ButtonID {
         Self::Wayland(value)
     }
 }
+#[cfg(xinput2)]
+impl From<xinput2::ButtonID> for ButtonID {
+    fn from(value: xinput2::ButtonID) -> Self {
+        Self::XInput2(value)
+    }
+}
 #[cfg(ink_rts)]
 impl From<ink::ButtonID> for ButtonID {
     fn from(value: ink::ButtonID) -> Self {
@@ -156,6 +196,8 @@ impl From<ink::ButtonID> for ButtonID {
 pub(crate) enum RawEventsIter<'a> {
     #[cfg(wl_tablet)]
     Wayland(std::slice::Iter<'a, crate::events::raw::Event<wl::ID>>),
+    #[cfg(wl_tablet)]
+    XInput2(std::slice::Iter<'a, crate::events::raw::Event<wl::ID>>),
     #[cfg(ink_rts)]
     Ink(std::slice::Iter<'a, crate::events::raw::Event<ink::ID>>),
 }
@@ -166,6 +208,8 @@ impl Iterator for RawEventsIter<'_> {
         match self {
             #[cfg(wl_tablet)]
             Self::Wayland(wl) => wl.next().cloned().map(crate::events::raw::Event::id_into),
+            #[cfg(xinput2)]
+            Self::XInput2(xi) => xi.next().cloned().map(crate::events::raw::Event::id_into),
             #[cfg(ink_rts)]
             Self::Ink(ink) => ink.next().cloned().map(crate::events::raw::Event::id_into),
         }
@@ -190,12 +234,14 @@ pub(crate) trait PlatformImpl {
 }
 
 /// Static dispatch between compiled backends.
-/// Enum cause why not, (almost?) always has one variant and is thus compiles away to the inner type transparently.
+/// Enum cause why not, in some cases this has one variant and is thus compiles away to the inner type transparently.
 /// Even empty enum is OK, since everything involving it becomes essentially `match ! {}` which is sound :D
 #[enum_dispatch::enum_dispatch(PlatformImpl)]
 pub(crate) enum PlatformManager {
     #[cfg(wl_tablet)]
     Wayland(wl::Manager),
+    #[cfg(xinput2)]
+    XInput2(xinput2::Manager),
     #[cfg(ink_rts)]
     Ink(ink::Manager),
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -197,7 +197,7 @@ pub(crate) enum RawEventsIter<'a> {
     #[cfg(wl_tablet)]
     Wayland(std::slice::Iter<'a, crate::events::raw::Event<wl::ID>>),
     #[cfg(wl_tablet)]
-    XInput2(std::slice::Iter<'a, crate::events::raw::Event<wl::ID>>),
+    XInput2(std::slice::Iter<'a, crate::events::raw::Event<xinput2::ID>>),
     #[cfg(ink_rts)]
     Ink(std::slice::Iter<'a, crate::events::raw::Event<ink::ID>>),
 }

--- a/src/platform/xinput2/mod.rs
+++ b/src/platform/xinput2/mod.rs
@@ -1,0 +1,31 @@
+pub type ID = ();
+pub type ButtonID = ();
+
+pub struct Manager;
+
+impl Manager {
+    pub unsafe fn build_window(_opts: crate::Builder, _window: u64) -> Self {
+        Self
+    }
+}
+
+impl super::PlatformImpl for Manager {
+    fn pads(&self) -> &[crate::pad::Pad] {
+        &[]
+    }
+    fn pump(&mut self) -> Result<(), crate::PumpError> {
+        Ok(())
+    }
+    fn raw_events(&self) -> super::RawEventsIter<'_> {
+        super::RawEventsIter::XInput2([].iter())
+    }
+    fn tablets(&self) -> &[crate::tablet::Tablet] {
+        &[]
+    }
+    fn timestamp_granularity(&self) -> Option<std::time::Duration> {
+        None
+    }
+    fn tools(&self) -> &[crate::tool::Tool] {
+        &[]
+    }
+}


### PR DESCRIPTION
A backend implementation using X11's `xinput` version 2 extension.

Closes #10.

Unfortunately, this implementation relies heavily on heuristics to detect the class and capabilities of hardware. There is not - as far as I can tell - a better way to go about it, and no resource exists listing the set of standard values. While I have a sizeable collection of hardware to test on, the heuristics will very likely need updating as more hardware is tried (pads with several rings, pads with sliders, tools with roll/distance/wheel/slider, airbrushes..., etc.).

Once implementation is finished (not yet, some breaking changes are still pending), I would greatly appreciate testing help to ensure this detects the full capabilities on all hardware. I will probably put out a call for this when the implementation is ready prior to making a release :3

- [x] Tool, Pad, Tablet hardware listing
- [x] Tool events
- [x] Pad events
- [ ] Hardware Add/Remove Events
- [ ] Timeout based `Out` events
- [ ] Mouse emulation
- [ ] Reduce the use of Xinput 1.x APIs which "clients are requested to avoid mixing" with Xinput 2 (whoops)
  - Some necessary XI1 calls have no XI2 counterpart. I'm confused.
- [ ] Refactor (a lot of this was written while I was pulling my hair out in utter bafflement)